### PR TITLE
Add onPressMain callback when main button is pressed

### DIFF
--- a/component/FloatingAction.js
+++ b/component/FloatingAction.js
@@ -86,12 +86,16 @@ class FloatingAction extends Component {
   };
 
   animateButton = () => {
-    const { overrideWithAction, actions, floatingIcon } = this.props;
+    const { overrideWithAction, actions, floatingIcon, onPressMain } = this.props;
 
     if (overrideWithAction) {
       this.handlePressItem(actions[0].name);
 
       return;
+    }
+
+    if (onPressMain) {
+      onPressMain(!this.state.active);
     }
 
     if (!this.state.active) {
@@ -283,7 +287,8 @@ FloatingAction.propTypes = {
   floatingIcon: PropTypes.any,
   overrideWithAction: PropTypes.bool, // use the first action like main action
   onPressItem: PropTypes.func,
-  distanceToEdge: PropTypes.number
+  distanceToEdge: PropTypes.number,
+  onPressMain: PropTypes.func
 };
 
 FloatingAction.defaultProps = {


### PR DESCRIPTION
I have the fab button in an app's main component so the back button will exit the app, but if the floating action menu is opened I wanted to override the back to close the floating action menu. With this PR I can know the state and close the menu using the reset method when it's opened.

If you prefer any other way of implementing this, please let me know.