### PR TITLE
Fix declaration that should be an export in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'react-native-floating-action' {
 
     type position = "right" | "left" | "center";
 
-    declare class FloatingAction extends Component<IFloatingActionProps> {
+    export class FloatingAction extends Component<IFloatingActionProps> {
     }
 
     export interface IActionProps {


### PR DESCRIPTION
This was causing a TypeScript compilation error for any module importing `react-native-floating-action` for me on TypeSscript `v3.3.1`:

```
node_modules/react-native-floating-action/index.d.ts:8:5 - error TS1038: A 'declare' modifier cannot be used in an already ambient context.

8     declare class FloatingAction extends Component<IFloatingActionProps> {
      ~~~~~~~


Found 1 error.
```

