### PR TITLE
tintColor prop added to FloatingActionItem for icon (when <Image />)

### DIFF
--- a/src/FloatingActionItem.js
+++ b/src/FloatingActionItem.js
@@ -99,7 +99,7 @@ class FloatingActionItem extends Component {
   }
 
   renderButton() {
-    const { buttonSize, icon, color, shadow } = this.props;
+    const { buttonSize, icon, color, shadow, tintColor } = this.props;
 
     let iconStyle;
 
@@ -110,6 +110,7 @@ class FloatingActionItem extends Component {
     }
 
     const propStyles = {
+      tintColor: tintColor,
       backgroundColor: color,
       width: buttonSize,
       height: buttonSize,
@@ -124,7 +125,7 @@ class FloatingActionItem extends Component {
         {React.isValidElement(icon) ? (
           icon
         ) : (
-          <Image style={iconStyle} source={icon} />
+          <Image style={[iconStyle, {tintColor: tintColor}]} source={icon} />
         )}
       </View>
     );
@@ -206,6 +207,7 @@ class FloatingActionItem extends Component {
 }
 
 FloatingActionItem.propTypes = {
+  tintColor: PropTypes.string,
   color: PropTypes.string,
   icon: PropTypes.any,
   name: PropTypes.string.isRequired,
@@ -245,6 +247,7 @@ FloatingActionItem.propTypes = {
 };
 
 FloatingActionItem.defaultProps = {
+  tintColor: '#fff',
   color: "#1253bc",
   distanceToEdge: 30,
   buttonSize: 40,


### PR DESCRIPTION
When you used icon: require("./assets/icons/icon.png") in actions, you want to be able to change the color of the icon.
Now you can use tintColor prop for it.
```javascript
actions: [
        {
          text: "Text",
          icon: require("./assets/icons/icon.png"),
          name: "name",
          position: 1,
          color: Colors.icon,
          textBackground: Colors.background,
          textColor: Colors.textColor,
          tintColor: Colors.tintColor //right here
        }
]
```