### PR TITLE
Fix warning in RN 0.62.0+

### DIFF
--- a/src/FloatingAction.js
+++ b/src/FloatingAction.js
@@ -85,14 +85,14 @@ class FloatingAction extends Component {
     if (prevProps.visible !== visible) {
       if (visible) {
         Animated.parallel([
-          Animated.spring(this.visibleAnimation, { toValue: 0 }),
-          Animated.spring(this.fadeAnimation, { toValue: 1 })
+          Animated.spring(this.visibleAnimation, { toValue: 0, useNativeDriver: false }),
+          Animated.spring(this.fadeAnimation, { toValue: 1, useNativeDriver: false })
         ]).start();
       }
       if (!visible) {
         Animated.parallel([
-          Animated.spring(this.visibleAnimation, { toValue: 1 }),
-          Animated.spring(this.fadeAnimation, { toValue: 0 })
+          Animated.spring(this.visibleAnimation, { toValue: 1, useNativeDriver: false }),
+          Animated.spring(this.fadeAnimation, { toValue: 0, useNativeDriver: false })
         ]).start();
       }
     }
@@ -134,12 +134,14 @@ class FloatingAction extends Component {
           actionsPaddingTopBottom +
           height -
           (isIphoneX() ? 40 : 0),
-        duration: 250
+        duration: 250,
+        useNativeDriver: false
       }),
       Animated.spring(this.mainBottomAnimation, {
         bounciness: 0,
         toValue: this.distanceToVerticalEdge + height - (isIphoneX() ? 40 : 0),
-        duration: 250
+        duration: 250,
+        useNativeDriver: false
       })
     ]).start();
   };
@@ -151,12 +153,14 @@ class FloatingAction extends Component {
       Animated.spring(this.actionsBottomAnimation, {
         bounciness: 0,
         toValue: buttonSize + this.distanceToVerticalEdge + actionsPaddingTopBottom,
-        duration: 250
+        duration: 250,
+        useNativeDriver: false
       }),
       Animated.spring(this.mainBottomAnimation, {
         bounciness: 0,
         toValue: this.distanceToVerticalEdge,
-        duration: 250
+        duration: 250,
+        useNativeDriver: false
       })
     ]).start();
   };
@@ -211,8 +215,8 @@ class FloatingAction extends Component {
     const { animated, onClose } = this.props;
 
     if (animated) {
-      Animated.spring(this.animation, { toValue: 0 }).start();
-      Animated.spring(this.actionsAnimation, { toValue: 0 }).start();
+      Animated.spring(this.animation, { toValue: 0, useNativeDriver: false }).start();
+      Animated.spring(this.actionsAnimation, { toValue: 0, useNativeDriver: false }).start();
     }
     this.updateState(
       {
@@ -255,12 +259,12 @@ class FloatingAction extends Component {
     if (!active) {
       if (!floatingIcon) {
         if (animated) {
-          Animated.spring(this.animation, { toValue: 1 }).start();
+          Animated.spring(this.animation, { toValue: 1, useNativeDriver: false }).start();
         }
       }
 
       if (animated) {
-        Animated.spring(this.actionsAnimation, { toValue: 1 }).start();
+        Animated.spring(this.actionsAnimation, { toValue: 1, useNativeDriver: false }).start();
 
         // only execute it for the background to prevent extra calls
         LayoutAnimation.configureNext({

--- a/src/FloatingActionItem.js
+++ b/src/FloatingActionItem.js
@@ -15,7 +15,8 @@ class FloatingActionItem extends Component {
 
     if (prevProps.active !== active && animated) {
       Animated.spring(this.animation, {
-        toValue: active ? 1 : 0
+        toValue: active ? 1 : 0,
+        useNativeDriver: false
       }).start();
     }
   }


### PR DESCRIPTION
As of [React Native 0.62.0](https://reactnative.dev/blog/2020/03/26/version-0.62#deprecations), `useNativeDriver` must always be set in `Animated`. 

Running this package in a RN 0.62.0+ app will result in the following error being show:
`Animated: 'useNativeDriver' was not specified. This is a required option and must be explicitly set to 'true' or 'false'`.

Closes #128 
closes #136 
closes #140 