### PR TITLE
Added possibility to not use TouchableNativeFeedback on android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ this.floatingAction.animateButton();
 | onOpen                  | function         |                                                                                                           | Function to be call after set state to **true**                                                                      |
 | onStateChange           | function         |                                                                                                           | Function to be call after every state change. Will return state object                                               |
 | animated                | boolean          | true                                                                                                      | Enable the animation                                                                                                 |
+| useNativeFeedback                | boolean          | true                                                                                                      | Android: Whether to use a TouchableNativeFeedback                                                                                                 |
 
 **Actions**
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,5 +57,6 @@ declare module "react-native-floating-action" {
     onOpen?: () => void;
     onStateChange?: () => void;
     animated?: boolean;
+    useNativeFeedback?: boolean;
   }
 }

--- a/src/FloatingAction.js
+++ b/src/FloatingAction.js
@@ -329,7 +329,8 @@ class FloatingAction extends Component {
       color,
       position,
       overrideWithAction,
-      animated
+      animated,
+      useNativeFeedback
     } = this.props;
     const { active } = this.state;
 
@@ -399,7 +400,7 @@ class FloatingAction extends Component {
       };
     }
 
-    const Touchable = getTouchableComponent();
+    const Touchable = getTouchableComponent(useNativeFeedback);
     const propStyles = {
       backgroundColor: mainButtonColor,
       bottom: this.mainBottomAnimation // I need to imporove this to run on native thread and not on JS thread
@@ -429,7 +430,7 @@ class FloatingAction extends Component {
         accessibilityLabel="Floating Action Button"
       >
         <Touchable
-          {...getRippleProps(mainButtonColor)}
+          {...getRippleProps(mainButtonColor, useNativeFeedback)}
           style={[styles.button, sizeStyle]}
           activeOpacity={0.85}
           onPress={this.animateButton}
@@ -598,7 +599,8 @@ FloatingAction.propTypes = {
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
   onPressBackdrop: PropTypes.func,
-  onStateChange: PropTypes.func
+  onStateChange: PropTypes.func,
+  useNativeFeedback: PropTypes.bool
 };
 
 FloatingAction.defaultProps = {
@@ -619,7 +621,8 @@ FloatingAction.defaultProps = {
   iconColor: '#fff',
   mainVerticalDistance: 0,
   animated: true,
-  shadow: {}
+  shadow: {},
+  useNativeFeedback: true
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Using `TouchableNativeFeedback` for android can cause problems with buttons layout, you can see it on the screenshot. It seems it was supposed to have possibility to configure `useNativeFeedback` property, but it wasn't actually added to documentation and code properly, thus it's always true. 
![Screenshot 2020-04-09 at 12 26 19](https://user-images.githubusercontent.com/63395280/78879972-57189f00-7a5d-11ea-9fcc-8a13c578c39c.png)
