### PR TITLE
Remove invalid props.style key `tintColor` supplied to `View`

### DIFF
--- a/src/FloatingActionItem.js
+++ b/src/FloatingActionItem.js
@@ -110,7 +110,6 @@ class FloatingActionItem extends Component {
     }
 
     const propStyles = {
-      tintColor: tintColor,
       backgroundColor: color,
       width: buttonSize,
       height: buttonSize,


### PR DESCRIPTION
Hello, 

When using react-native-floating-action in web, the following error is shown in the console:

![image](https://user-images.githubusercontent.com/7410981/87731500-81c27400-c77f-11ea-8b71-f13efb81f00a.png)

Removed it to reduce the noise and focus on errors that actually be surfacing something important. 

Let me know what do you think!