### PR TITLE
Issue/#148/missing tint color prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ declare module "react-native-floating-action" {
   }
 
   export interface IFloatingActionProps {
-    tintColor: string;
+    tintColor?: string;
     actions?: IActionProps[];
     color?: string;
     distanceToEdge?: number | { vertical: number; horizontal: number };

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare module "react-native-floating-action" {
     shadowRadius?: number;
   };
 
-  export class FloatingAction extends Component<IFloatingActionProps> {}
+  export class FloatingAction extends Component<IFloatingActionProps> { }
 
   export interface IActionProps {
     color?: string;
@@ -30,9 +30,11 @@ declare module "react-native-floating-action" {
     render?: () => void;
     animated?: boolean;
     shadow?: shadowType;
+    tintColor?: string
   }
 
   export interface IFloatingActionProps {
+    tintColor: string;
     actions?: IActionProps[];
     color?: string;
     distanceToEdge?: number | { vertical: number; horizontal: number };

--- a/src/FloatingAction.js
+++ b/src/FloatingAction.js
@@ -501,7 +501,7 @@ class FloatingAction extends Component {
           const textColor = action.textColor || action.actionsTextColor;
           const textBackground =
             action.textBackground || action.actionsTextBackground;
-          const tintColor =
+          const tintColorIcon =
             action.tintColor || tintColor || '#fff';
 
           return (
@@ -510,7 +510,7 @@ class FloatingAction extends Component {
               distanceToEdge={distanceToEdge}
               key={action.name}
               textColor={textColor}
-              tintColor={tintColor}
+              tintColor={tintColorIcon}
               textBackground={textBackground}
               shadow={this.getShadow()}
               {...action}

--- a/src/FloatingAction.js
+++ b/src/FloatingAction.js
@@ -42,9 +42,9 @@ class FloatingAction extends Component {
     );
     this.actionsBottomAnimation = new Animated.Value(
       props.buttonSize +
-        this.distanceToVerticalEdge +
-        props.actionsPaddingTopBottom +
-        props.mainVerticalDistance
+      this.distanceToVerticalEdge +
+      props.actionsPaddingTopBottom +
+      props.mainVerticalDistance
     );
     this.animation = new Animated.Value(0);
     this.actionsAnimation = new Animated.Value(0);
@@ -181,7 +181,7 @@ class FloatingAction extends Component {
       overrideWithAction,
       iconWidth,
       iconHeight,
-      iconColor
+      iconColor,
     } = this.props;
 
     if (overrideWithAction) {
@@ -208,7 +208,7 @@ class FloatingAction extends Component {
       );
     }
 
-    return <AddIcon width={iconWidth} height={iconHeight} backgroundColor={iconColor}  />;
+    return <AddIcon width={iconWidth} height={iconHeight} backgroundColor={iconColor} />;
   };
 
   reset = () => {
@@ -455,7 +455,8 @@ class FloatingAction extends Component {
       overrideWithAction,
       distanceToEdge,
       actionsPaddingTopBottom,
-      animated
+      animated,
+      tintColor,
     } = this.props;
     const { active } = this.state;
 
@@ -500,6 +501,8 @@ class FloatingAction extends Component {
           const textColor = action.textColor || action.actionsTextColor;
           const textBackground =
             action.textBackground || action.actionsTextBackground;
+          const tintColor =
+            action.tintColor || tintColor || '#fff';
 
           return (
             <FloatingActionItem
@@ -507,6 +510,7 @@ class FloatingAction extends Component {
               distanceToEdge={distanceToEdge}
               key={action.name}
               textColor={textColor}
+              tintColor={tintColor}
               textBackground={textBackground}
               shadow={this.getShadow()}
               {...action}
@@ -552,6 +556,7 @@ class FloatingAction extends Component {
 }
 
 FloatingAction.propTypes = {
+  tintColor: PropTypes.string,
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       color: PropTypes.string,
@@ -562,7 +567,8 @@ FloatingAction.propTypes = {
       textBackground: PropTypes.string,
       textColor: PropTypes.string,
       component: PropTypes.func,
-      animated: PropTypes.bool
+      animated: PropTypes.bool,
+      tintColor: PropTypes.string
     })
   ),
   animated: PropTypes.bool,


### PR DESCRIPTION
# DETAILS
so prop was already there but not accessible for us.

if you want to still use tint color you  are welcome to use it individually by item / by group 

# HOW TO VERIFY
>INDIVIDUAL CASE
![image](https://user-images.githubusercontent.com/48217522/125197919-48530600-e225-11eb-8bd0-e9d4758ac787.png)


>GROUP CASE
![image](https://user-images.githubusercontent.com/48217522/125197888-22c5fc80-e225-11eb-988c-2dd7c994753b.png)


>SHOW CASE 
- soccer ball = null
- group elements = pink

![image](https://user-images.githubusercontent.com/48217522/125199137-6b33e900-e22a-11eb-9cc0-0b642391e3b4.png)

