### PR TITLE
Add iconColor to IFloatingActionProps interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,7 @@ declare module "react-native-floating-action" {
     actionsPaddingTopBottom?: number;
     iconWidth?: number;
     iconHeight?: number;
+    iconColor?: string;
     buttonSize?: number;
     listenKeyboard?: boolean;
     dismissKeyboardOnPress?: boolean;


### PR DESCRIPTION
The prop iconColor was missing in the IFloatingActionProps interface which caused a typescript error. I am assuming it's meant to be a string to represent a hex color code.