### PR TITLE
Fixes the lack of tinColor using iconColor

### DIFF
--- a/src/FloatingAction.js
+++ b/src/FloatingAction.js
@@ -193,7 +193,7 @@ class FloatingAction extends Component {
         return icon;
       }
       return (
-        <Image style={{ width: iconWidth, height: iconHeight }} source={icon} />
+        <Image style={{ width: iconWidth, height: iconHeight, tintColor: iconColor }} source={icon} />
       );
     }
 
@@ -204,7 +204,7 @@ class FloatingAction extends Component {
 
       return (
         <Image
-          style={{ width: iconWidth, height: iconHeight }}
+          style={{ width: iconWidth, height: iconHeight, tintColor: iconColor }}
           source={floatingIcon}
         />
       );


### PR DESCRIPTION
The main button doesn't apply iconColor attribute properly on the main floating button. This commit fixes this problem.